### PR TITLE
Add Rails 4.2 compatibility

### DIFF
--- a/lib/simple_form_object.rb
+++ b/lib/simple_form_object.rb
@@ -1,4 +1,5 @@
 require "simple_form_object/version"
+require "simple_form_object/attribute"
 require "active_model"
 require "active_support"
 
@@ -14,6 +15,10 @@ module SimpleFormObject
       _attributes << Attribute.new(name, type, options)
     end
 
+    def route_as(model_name)
+      @model_name = model_name.to_s.camelize
+    end
+
     def _attributes
       @_attributes ||= []
     end
@@ -23,7 +28,13 @@ module SimpleFormObject
     end
 
     def model_name
-      ActiveModel::Name.new(self, nil, self.to_s.gsub(/Form$/, ''))
+      ActiveModel::Name.new(self, nil, model_name_for_routing)
+    end
+
+    private
+
+    def model_name_for_routing
+      @model_name || to_s.gsub(/Form$/, "")
     end
   end
 
@@ -46,34 +57,7 @@ module SimpleFormObject
     attribs
   end
 
-  class Attribute
-    def initialize(name, type = nil, options)
-      @name = name
-      @type = type || :string
-      @options = options
-
-      extract_options
-    end
-
-    attr_accessor :name, :type, :options
-
-    def fake_column
-      self
-    end
-
-    def apply_default_to(form)
-      if form.send(@name).nil?
-        form.send("#{@name}=", @default) if @apply_default
-      end
-    end
-
-    private
-
-    def extract_options
-      @apply_default = true
-      @default = options.fetch(:default) { @apply_default = false; nil }
-      @skip_validations = options.fetch(:skip_validations, false)
-    end
+  def has_attribute?(attribute)
+    attributes.key?(attribute)
   end
-
 end

--- a/lib/simple_form_object/attribute.rb
+++ b/lib/simple_form_object/attribute.rb
@@ -1,0 +1,39 @@
+module SimpleFormObject
+  class Attribute
+    def initialize(name, type = nil, options)
+      @name = name
+      @type = type || :string
+      @options = options
+
+      extract_options
+    end
+
+    attr_accessor :name, :type, :options
+
+    def fake_column
+      self
+    end
+
+    def apply_default_to(form)
+      if form.send(@name).nil?
+        form.send("#{@name}=", @default) if @apply_default
+      end
+    end
+
+    def number?
+      %i(integer float decimal).include?(type)
+    end
+
+    def limit
+      nil
+    end
+
+    private
+
+    def extract_options
+      @apply_default = true
+      @default = options.fetch(:default) { @apply_default = false; nil }
+      @skip_validations = options.fetch(:skip_validations, false)
+    end
+  end
+end

--- a/spec/attribute_spec.rb
+++ b/spec/attribute_spec.rb
@@ -53,6 +53,47 @@ describe SimpleFormObject::Attribute do
         expect(form.foo).to eq false
       end
     end
+  end
 
+  describe '#limit' do
+    subject(:attribute) { SimpleFormObject::Attribute.new(:name, :string, {}) }
+
+    it 'returns nil' do
+      expect(subject.limit).to be_nil
+    end
+  end
+
+  describe '#number?' do
+    context 'when attribute is an integer' do
+      subject(:attribute) { SimpleFormObject::Attribute.new(:name, :integer, {}) }
+
+      it 'returns true' do
+        expect(subject).to be_number
+      end
+    end
+
+    context 'when attribute is a float' do
+      subject(:attribute) { SimpleFormObject::Attribute.new(:name, :float, {}) }
+
+      it 'returns true' do
+        expect(subject).to be_number
+      end
+    end
+
+    context 'when attribute is a decimal' do
+      subject(:attribute) { SimpleFormObject::Attribute.new(:name, :decimal, {}) }
+
+      it 'returns true' do
+        expect(subject).to be_number
+      end
+    end
+
+    context 'when attribute is a string' do
+      subject(:attribute) { SimpleFormObject::Attribute.new(:name, :string, {}) }
+
+      it 'returns false' do
+        expect(subject).not_to be_number
+      end
+    end
   end
 end

--- a/spec/model_spec.rb
+++ b/spec/model_spec.rb
@@ -67,20 +67,56 @@ describe 'SimpleFormObject' do
   end
 
   describe '.model_name' do
-    let(:klass) do
-      class KlassForm
-        include SimpleFormObject
+    context 'by convention' do
+      let(:klass) do
+        class KlassForm
+          include SimpleFormObject
+        end
+
+        KlassForm
       end
 
-      KlassForm
+      it 'should return an ActiveModel::Name' do
+        expect(klass.model_name).to be_a_kind_of ActiveModel::Name
+      end
+
+      it 'should remove Form from the name of the class' do
+        expect(klass.model_name.name).to eq 'Klass'
+      end
     end
 
-    it 'should return an ActiveModel::Name' do
-      expect(klass.model_name).to be_a_kind_of ActiveModel::Name
+    context 'by declaration' do
+      let(:klass) do
+        class KlassForm
+          include SimpleFormObject
+
+          route_as :custom
+        end
+
+        KlassForm
+      end
+
+      it 'should return an ActiveModel::Name' do
+        expect(klass.model_name).to be_a_kind_of ActiveModel::Name
+      end
+
+      it 'should remove Form from the name of the class' do
+        expect(klass.model_name.name).to eq 'Custom'
+      end
+    end
+  end
+
+  describe '#has_attribute?' do
+    before do
+      klass.attribute :foo
     end
 
-    it 'should remove Form from the name of the class' do
-      expect(klass.model_name.name).to eq "Klass"
+    it 'returns true for a declared attribute' do
+      expect(instance.has_attribute?(:foo)).to be(true)
+    end
+
+    it 'returns false for a declared attribute' do
+      expect(instance.has_attribute?(:bar)).to be(false)
     end
   end
 end


### PR DESCRIPTION
I needed to add a few methods to allow this gem to work with Rails 4.2
and simple_form 3.1. These methods were as follows:

`Attribute#number?` - returns true if the attribute type is numerical,
otherwise returns false.

`Attribute#limit` - returns the database column size limit which
simple_form uses to set maxlength/size attributes on the input controls
if there are no length validations. I return nil here so no html
attributes are added. If you add length validations then these do still
result in html attributes for length being added.

`SimpleFormObject#has_attribute?` - returns true if the passed attribute
has been declared for the form object otherwise returns false.

In addition to these changes I have also added a new class method for
overriding the model name used (for routing). Now you can do this:

```
class FooForm
  include SimpleFormObject

  route_as :bar
end
```

This will result in the form using the path helpers `bars_path` rather
than `foos_path` etc.